### PR TITLE
Gainmatch

### DIFF
--- a/scripts/gainMatcher.js
+++ b/scripts/gainMatcher.js
@@ -187,14 +187,18 @@ function updateODB(obj){
     var channel = obj[0].chan,
         gain = obj[1].gain,
         offset = obj[2].offset,
-        i, position, urls = [];
+        i, g, o, position, urls = [];
 
     //for every griffin channel, update the gains and offsets:
     for(i=0; i<channel.length; i++){
         position = dataStore.GRIFFINdetectors.indexOf(channel[i]);
         if(position != -1){
-            gain[i] = dataStore.fitResults[dataStore.GRIFFINdetectors[position]+'_Pulse_Height'][2][1];
-            offset[i] = dataStore.fitResults[dataStore.GRIFFINdetectors[position]+'_Pulse_Height'][2][0];
+            g = dataStore.fitResults[dataStore.GRIFFINdetectors[position]+'_Pulse_Height'][2][1];
+            g = isNumeric(g) ? g : 1;
+            gain[i] = g;
+            o = dataStore.fitResults[dataStore.GRIFFINdetectors[position]+'_Pulse_Height'][2][0];
+            o = isNumeric(o) ? o : 0;
+            offset[i] = o;
         }
     }
 

--- a/scripts/gainMatcher.js
+++ b/scripts/gainMatcher.js
@@ -192,7 +192,7 @@ function updateODB(obj){
     //for every griffin channel, update the gains and offsets:
     for(i=0; i<channel.length; i++){
         position = dataStore.GRIFFINdetectors.indexOf(channel[i]);
-        if(position != -1){
+        if( (position != -1) && (document.getElementById(channel[i]+'write').checked)){
             g = dataStore.fitResults[dataStore.GRIFFINdetectors[position]+'_Pulse_Height'][2][1];
             g = isNumeric(g) ? g : 1;
             gain[i] = g;

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -187,7 +187,11 @@ function prepareTemplates(templates){
     return guts
 }
 
-//promisePartial('footer').then(function(template){dataStore.foot = template })
+function isNumeric(n) {
+    // is n a number?
+
+    return !Number.isNaN(parseFloat(n)) && Number.isFinite(n);
+}
 
 function subtractHistograms(h0, h1){
     // perform element-wise subtraction h1-h0

--- a/templates/gainMatchReport/gainMatchReport.html
+++ b/templates/gainMatchReport/gainMatchReport.html
@@ -90,6 +90,9 @@
             document.getElementById(this.wrapID + 'peak1').onchange = this.customEnergy.bind(this);
             document.getElementById(this.wrapID + 'peak2').onchange = this.customEnergy.bind(this);
 
+            //plug in write to odb toggles
+            document.getElementById('writeAllChannels').onchange = this.toggleAllODBWrites.bind(this);
+
             //set up fit callbacks
             dataStore.viewers[dataStore.plots[0]].fitCallback = this.fitCallback.bind(this);
 
@@ -103,7 +106,6 @@
                     window.alert('You need to perform the gain match (see button at top of page) before writing results to the ODB.');
                     document.getElementById('dismissODBmodal').click();
                 }
-                console.log('writing')
                 promiseScript(dataStore.ODBrequests[0]);
             }
         },
@@ -382,9 +384,10 @@
                         || isNaN(dataStore.fitResults[keys[i]][1][1])
                     )
                 ){
-                    document.getElementById(this.wrapID + keys[i].slice(0,10) + 'row').setAttribute('style', 'background-color: #FF0000;')
+                    document.getElementById(this.wrapID + keys[i].slice(0,10) + 'row').setAttribute('style', 'background-color: #FF0000;');
+                    document.getElementById(keys[i].slice(0,10) + 'write').checked = false;
                 } else{
-                    document.getElementById(this.wrapID + keys[i].slice(0,10) + 'row').setAttribute('style', '')
+                    document.getElementById(this.wrapID + keys[i].slice(0,10) + 'row').setAttribute('style', '');
                 }
             }
         },
@@ -471,6 +474,20 @@
                 document.getElementById(this.wrapID + 'writeToODB').removeAttribute('disabled');
             else
                 document.getElementById(this.wrapID + 'writeToODB').setAttribute('disabled', true);
+        }
+
+        this.toggleAllODBWrites = function(){
+            // make each channel's odb write toggle match the master switch
+
+            var toggles = document.getElementsByClassName('write-to-odb'),
+                master = document.getElementById('writeAllChannels'),
+                state = master.checked,
+                i;
+
+            for(i=0; i<toggles.length; i++){
+                toggles[i].checked = state;
+            }
+
         }
 
     }

--- a/templates/gainMatchReport/gainMatchReport.html
+++ b/templates/gainMatchReport/gainMatchReport.html
@@ -202,8 +202,7 @@
         },
 
         this.guessPeaks = function(spectrumName, data){
-            //given a spectrum <data>, identify the bins corresponding to the maxima of the two largest peaks
-            //around where we expect the calibration peaks to fall (+- 30 bins of bin==peak energy in kev)
+            //given a spectrum <data>, identify the bins corresponding to the maxima of the two largest peaks.
             //register a range around those peaks as our automated guesses for where the gammas of interest lie.
             //<spectrumName>: string; name of spectrum, per names from analyzer
             //<data>: array; bin contents for a spectrum, array index == bin number.
@@ -212,12 +211,10 @@
             var i, max, center, ROIlower, ROIupper, buffer,
             dataCopy = JSON.parse(JSON.stringify(data)),
             ROIwidth = 5;
-            searchWidth = 30;
-            var lowEnergy = parseInt(document.getElementById(this.wrapID + 'peak1').value,10);
-            var highEnergy = parseInt(document.getElementById(this.wrapID + 'peak2').value,10);
+            searchWidth = 30,
 
-            max = Math.max.apply(Math, dataCopy.slice(lowEnergy - searchWidth, lowEnergy + searchWidth));
-            center = dataCopy.slice(lowEnergy - searchWidth, lowEnergy + searchWidth).indexOf(max) + lowEnergy - searchWidth;
+            max = Math.max.apply(Math, dataCopy);
+            center = dataCopy.indexOf(max);
             ROIlower = [center - ROIwidth, center + ROIwidth];
 
             //mask out this peak so we can find the next biggest
@@ -225,8 +222,8 @@
                 dataCopy[i] = 0
             }
 
-            max = Math.max.apply(Math, dataCopy.slice(highEnergy - searchWidth, highEnergy + searchWidth));
-            center = dataCopy.slice(highEnergy - searchWidth, highEnergy + searchWidth).indexOf(max) + highEnergy - searchWidth;
+            max = Math.max.apply(Math, dataCopy);
+            center = dataCopy.indexOf(max);
             ROIupper = [center - ROIwidth, center + ROIwidth];
 
             //make sure lower contains the lower energy peak (currently contains the highest intensity peak)

--- a/templates/gainMatchReport/matchReportTable.html
+++ b/templates/gainMatchReport/matchReportTable.html
@@ -1,10 +1,11 @@
 <template id='matchReportTable'>
     <tr>
-        <td>Detector</td>
-        <td>Peak 1 Channel</td>
-        <td>Peak 2 Channel</td>
-        <td>Slope</td>
-        <td>Intercept</td>
+        <td class='col-md-2'>Detector</td>
+        <td class='col-md-2'>Peak 1 Channel</td>
+        <td class='col-md-2'>Peak 2 Channel</td>
+        <td class='col-md-2'>Slope</td>
+        <td class='col-md-2'>Intercept</td>
+        <td class='col-md-2 center'>Write to ODB <input id='writeAllChannels' type='checkbox' checked></input><td>
     </tr>
     {{# detectors}}
         <tr id='{{id}}{{.}}row'>
@@ -13,6 +14,9 @@
             <td id='{{id}}{{.}}chan2'>-</td>
             <td id='{{id}}{{.}}slope'>-</td>
             <td id='{{id}}{{.}}intercept'>-</td>
+            <td class='center'>
+                <input id='{{.}}write' class='write-to-odb' type='checkbox' checked></input>
+            </td>
         </tr>
     {{/ detectors}}
 </template>


### PR DESCRIPTION
This PR will address:
- [x] #22 defaulting to gain=1 and offset=0 when fits fail
- [x] #26 supporting subsets of channels to write to ODB
- [ ] ~~#27 a more sensible peak-finding algorithm.~~ deferred
#27 is the most problematic; previously, we started by guessing 1 bin = 1 keV, and hoping that got us pretty near the right peaks, which it seemed to - until we realized we were calibrating on already-calibrated energy spectra. The current implementation takes the two tallest peaks, which is probably ok for 60Co, probably not for 152Eu, and definitely not for arbitrary calibration sources; suggestions welcome on how to do this better. Totally cursory inspection suggests raw spectra can be out by a relative 400 bins (see below), meaning search regions would have to be at least this wide, and be able to reliably choose the right peak from the many that could appear in that wide a range.

![screen shot 2016-06-30 at 4 48 41 pm](https://cloud.githubusercontent.com/assets/1896943/16507957/00da855e-3ee3-11e6-877e-07304cf06356.png)
