### PR TITLE
fixes #27

### DIFF
--- a/gainMatcher.html
+++ b/gainMatcher.html
@@ -19,6 +19,7 @@
         <link id='header' rel="import" href="templates/header/header.html">
         <link id='gainMatchReport' rel="import" href="templates/gainMatchReport/gainMatchReport.html">
         <link id='matchReportTable' rel="import" href="templates/gainMatchReport/matchReportTable.html">
+        <link id='gainMatchSetupBar' rel="import" href="templates/gainMatchReport/gainMatchSetupBar.html">
         <link id='plotGrid' rel="import" href="templates/plotGrid/plotGrid.html">
         <link id='plotControl' rel="import" href="templates/plotControl/plotControl.html">
         <link id='plotListLite' rel="import" href="templates/plotList/plotListLite.html">
@@ -29,7 +30,32 @@
     <body>
         <div id='head'></div>
 
-        <div id='gainMatcher'></div>
+        <!--helpful hints-->
+        <div class='col-md-6'>
+            <div id='waitMessage' class="alert alert-warning" role="alert">
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+                Spectra downloading, please wait...
+            </div>
+
+            <div id='regionMessage' class="alert alert-warning hidden" role="alert">
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+                Shift-click either end of a single line crossing both peaks you'd like to calibrate on.<br>
+                Tip: aim low and wide! 
+            </div>
+
+            <div id='pickerMessage' class="alert alert-warning hidden" role="alert">
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+                Enter the each peak's position along the line counting from the left, and its energy.
+            </div>
+
+            <div id='reviewMessage' class="alert alert-warning hidden" role="alert">
+                <span class="glyphicon glyphicon-check" aria-hidden="true"></span>
+                Review the results in the table below, and refit any pathological peaks one at a time.
+            </div>
+        </div>
+
+        <!--peak definition-->
+        <div id='setupBar' class='col-md-12'></div>
 
         <!--Spectrum Plotting-->
         <div id='plotRegion' class='sectionWrapper'>
@@ -54,6 +80,8 @@
             </div>
         </div>
 
+        <div id='gainMatcher'></div>
+
         <!--Resolution-->
         <div id='resolutionSection' class='sectionWrapper'>
             <div id='resolutionWrap' class='col-md-6 item'>
@@ -69,10 +97,10 @@
                 dataStore._plotGrid = new plotGrid('plottingGrid');
                 dataStore._plotControl = new plotControl('plotCtrl', 'horizontal');
                 dataStore._plotListLite = new plotListLite('plotList');
-                dataStore._gainMatchReport = new gainMatchReport('gainMatcher');
+                dataStore._gainMatchReport = new gainMatchReport('gainMatcher', 'setupBar');
                 dataStore._striptool = new striptool('resolution');
 
-                dataStore.templates = prepareTemplates(['header', 'gainMatchReport', 'matchReportTable', 'plotGrid', 'plotControl', 'plotListLite', 'striptool', 'footer']);
+                dataStore.templates = prepareTemplates(['header', 'gainMatchReport', 'matchReportTable', 'gainMatchSetupBar', 'plotGrid', 'plotControl', 'plotListLite', 'striptool', 'footer']);
 
                 setupHeader('head', 'Gain Matcher');
                 dataStore._plotGrid.setup();
@@ -83,6 +111,9 @@
                 dataStore._gainMatchReport.setup();
                 dataStore._striptool.setup();
                 setupFooter('foot');
+
+                // set up shift-click behavior:
+                dataStore.viewers[dataStore.plots[0]].shiftclickCallback = shiftclick;
 
                 //don't want additional plots in this app
                 deleteNode('plottingGridnewPlotButton');

--- a/scripts/gainMatcher.js
+++ b/scripts/gainMatcher.js
@@ -59,6 +59,7 @@ function setupDataStore(){
     dataStore.lowPeakResolution.fill(0,64);                             //start with zeroes
     dataStore.highPeakResolution = [];                                  //as lowPeakResolution
     dataStore.highPeakResolution.fill(0,64);                            //start with zeroes
+    dataStore.searchRegion = []                                         //[x_start, x_finish, y for peak search bar]
 
     dataStore.GRIFFINdetectors = [                                      //10-char codes of all possible griffin detectors.
             'GRG01BN00A',
@@ -160,8 +161,12 @@ function setupDataStore(){
 setupDataStore();
 
 function fetchCallback(){
+    // change messages
     deleteNode('waitMessage');
-    //document.getElementById('gainMatcher').configure();
+    document.getElementById('regionMessage').classList.remove('hidden');
+
+    //show first plot
+    dataStore._plotListLite.snapToTop();
 }
 
 function loadData(DAQ){
@@ -221,4 +226,30 @@ function updateODB(obj){
 
     //get rid of the modal
     document.getElementById('dismissODBmodal').click();
+}
+
+function shiftclick(clickCoords){
+    // callback for shift-click on plot - draw a horizontal line as the peak search region.
+    // this == spectrumViewer object
+
+    var buffer
+
+    if(dataStore.searchRegion.length == 0){
+        dataStore.searchRegion[0] = clickCoords.x;
+        dataStore.searchRegion[2] = clickCoords.y;
+    } else if (dataStore.searchRegion.length == 3){
+        dataStore.searchRegion[1] = clickCoords.x;
+        if(dataStore.searchRegion[0] > dataStore.searchRegion[1]){
+            buffer = dataStore.searchRegion[0];
+            dataStore.searchRegion[0] = dataStore.searchRegion[1];
+            dataStore.searchRegion[1] = buffer;
+        }
+        this.addLine('searchRegion', dataStore.searchRegion[0], dataStore.searchRegion[2], dataStore.searchRegion[1], dataStore.searchRegion[2], '#00FFFF');
+        this.plotData();
+
+        //user guidance
+        deleteNode('regionMessage');
+        document.getElementById('pickerMessage').classList.remove('hidden');
+        document.getElementById('fitAll').classList.remove('disabled');
+    }
 }

--- a/scripts/gammaSpectrum.js
+++ b/scripts/gammaSpectrum.js
@@ -103,6 +103,7 @@ function spectrumViewer(canvasID){
     this.XMouseLimitxMin = 0; //limits selected with the cursor
     this.XMouseLimitxMax = 0;
     this.clickBounds = [];
+    this.shiftclickCallback = function(){}; //callback on shift+click, passed {x,y} in bins, spectrumViewer bound as this
 
 	//plot repaint loop
 	this.RefreshTime = 3; //seconds to wait before a plot refresh when requested
@@ -1131,16 +1132,22 @@ function spectrumViewer(canvasID){
 	}.bind(this);
 
 	this.canvas.onmousedown = function(event){
-		if(event.button == 0){
+		var x, y
+		if(event.shiftKey){
+			x = this.xpix2bin(this.canvas.relMouseCoords(event).x)
+			y = this.ypix2bin(this.canvas.relMouseCoords(event).y)
+			this.shiftclickCallback.bind(this)({x:x,y:y});
+		}
+		else if(event.button == 0){
 			this.highlightStart = this.canvas.relMouseCoords(event).x;
-			this.XMouseLimitxMin = parseInt((this.canvas.relMouseCoords(event).x-this.leftMargin)/this.binWidth + this.XaxisLimitMin);
+			this.XMouseLimitxMin = this.xpix2bin(this.canvas.relMouseCoords(event).x);
 		}
 	}.bind(this);
 
 	this.canvas.onmouseup = function(event){
-			if(event.button == 0){
+			if(event.button == 0 && !event.shiftKey){
 				this.highlightStart = -1;
-				this.XMouseLimitxMax = parseInt((this.canvas.relMouseCoords(event).x-this.leftMargin)/this.binWidth + this.XaxisLimitMin); 
+				this.XMouseLimitxMax = this.xpix2bin(this.canvas.relMouseCoords(event).x); 
 				this.DragWindow();
 			}
 	}.bind(this);
@@ -1152,6 +1159,16 @@ function spectrumViewer(canvasID){
 	//right clicking does obnoxious focus things, messes with canvas onclicks.
 	this.canvas.oncontextmenu = function(){
 		return false;
+	};
+
+	this.xpix2bin = function(x){
+		// convert the x pixel position returned by relMouseCoords into a bin number
+		return parseInt((x-this.leftMargin)/this.binWidth + this.XaxisLimitMin);
+	};
+
+	this.ypix2bin = function(y){
+		// convert the y pixel position returned by relMouseCoords into a bin number
+		return Math.floor((this.canvas.height - this.bottomMargin - y)/this.yAxisPixLength * this.YaxisLength + this.YaxisLimitMin);
 	};
 }
 

--- a/templates/gainMatchReport/gainMatchReport.html
+++ b/templates/gainMatchReport/gainMatchReport.html
@@ -3,25 +3,6 @@
 <template id='gainMatchReport'>
     <div class='sectionWrapper item'>
         <div class='col-md-12'>
-            <label for='{{id}}calibrationSource'>Calibration Source:</label>
-            <select id='{{id}}calibrationSource' class='rowElement'>
-                <option selected value='Co-60'><sup>60</sup>Co</option>
-                <option value='Eu-152'><sup>152</sup>Eu</option>
-                <option value='custom'>Custom</option>
-            </select>
-
-            <label for='{{id}}peak1'>First Peak (keV):</label>
-            <input type='number' id='{{id}}peak1' class='rowElement' value=1173></input>
-            <label for='{{id}}peak1'>Second Peak (keV):</label>
-            <input type='number' id='{{id}}peak2' class='rowElement' value=1332></input>
-            <button type="button" class="btn btn-primary" id='{{id}}fitAll' disabled>
-                <span id='{{id}}snapPin' class="glyphicon glyphicon-flash" aria-hidden="true"></span> Automate Gain Match
-            </button>
-            <span id='waitMessage'>Spectra downloading, please wait...</span>
-            <div class="progress">
-              <div id='{{id}}progress' class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
-            </div>
-
             <table id='{{id}}gainMatchingResults' class='table gainTable'></table>
 
             <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
@@ -58,13 +39,22 @@
 </template>
 
 <script>
-    function gainMatchReport(wrapID){
+    function gainMatchReport(wrapID, setupWrapID){
 
         this.wrapID = wrapID;
+        this.setupWrapID = setupWrapID;
         this.wrap = document.getElementById(wrapID);
+        this.setupWrap = document.getElementById(setupWrapID)
 
         this.setup = function(){
-            //inject template
+            //inject templates
+            this.setupWrap.innerHTML = Mustache.to_html(
+                dataStore.templates.gainMatchSetupBar, 
+                {
+                    'id': this.setupWrapID, 
+                }
+            );
+
             this.wrap.innerHTML = Mustache.to_html(
                 dataStore.templates.gainMatchReport, 
                 {
@@ -81,14 +71,12 @@
             );
 
             //plug in fit all button
-            document.getElementById(this.wrapID + 'fitAll').onclick = this.fitAll.bind(this);
-            document.getElementById(this.wrapID + 'fitAll').removeAttribute('disabled');
+            document.getElementById('fitAll').onclick = this.fitAll.bind(this);
+            document.getElementById('fitAll').removeAttribute('disabled');
 
-            //plug in source dropdown
-            document.getElementById(this.wrapID + 'calibrationSource').onchange = this.updateEnergies.bind(this);
             //plug in peak energy inputs
-            document.getElementById(this.wrapID + 'peak1').onchange = this.customEnergy.bind(this);
-            document.getElementById(this.wrapID + 'peak2').onchange = this.customEnergy.bind(this);
+            document.getElementById('peak1').onchange = this.customEnergy.bind(this);
+            document.getElementById('peak2').onchange = this.customEnergy.bind(this);
 
             //plug in write to odb toggles
             document.getElementById('writeAllChannels').onchange = this.toggleAllODBWrites.bind(this);
@@ -114,13 +102,14 @@
             //fit all spectra to the peaks defined.
             //this: gainMatchReport object
 
-            var i, keys = Object.keys(dataStore.rawData);
+            var i, keys = Object.keys(dataStore.rawData),
+                buffer = dataStore.currentPlot //keep track of whatever was originally plotted so we can return to it
 
             releaser(
                 function(i){
                     var keys = Object.keys(dataStore.rawData);
                     this.fitSpectra(keys[i])
-                    document.getElementById(this.wrapID + 'progress').setAttribute('style', 'width:' + (100*(keys.length - i) / keys.length) + '%' )   
+                    document.getElementById('progress').setAttribute('style', 'width:' + (100*(keys.length - i) / keys.length) + '%' )   
                 }.bind(this),
 
                 function(){
@@ -128,8 +117,12 @@
                     //set up fit line re-drawing
                     dataStore.viewers[dataStore.plots[0]].drawCallback = this.addFitLines;
 
+                    //comunicate with the user
+                    deleteNode('pickerMessage')
+                    document.getElementById('reviewMessage').classList.remove('hidden');
+
                     //leave the viewer pointing at the first spectrum for fitting
-                    dispatcher({}, 'fitAllComplete')
+                    dispatcher({target: buffer}, 'fitAllComplete')
 
                 }.bind(this),
 
@@ -210,36 +203,24 @@
             //<data>: array; bin contents for a spectrum, array index == bin number.
             //this: gainMatchReport object
 
-            var i, max, center, ROIlower, ROIupper, buffer,
-            dataCopy = JSON.parse(JSON.stringify(data)),
-            ROIwidth = 5;
-            searchWidth = 30,
+            var lowPeakIndex = parseInt(document.getElementById('peak1position').value,10),
+                highPeakIndex = parseInt(document.getElementById('peak2position').value,10),
+                centers = [],
+                ROIwidth = 5,
+                i;
 
-            max = Math.max.apply(Math, dataCopy);
-            center = dataCopy.indexOf(max);
-            ROIlower = [center - ROIwidth, center + ROIwidth];
+            // identify all peak centers of peaks that cross the search region threshold
+            for(i=dataStore.searchRegion[0]; i<dataStore.searchRegion[1]; i++){
+                if(data[i] > dataStore.searchRegion[2] && data[i] > data[i-1] && data[i] > data[i+1])
+                    centers.push(i)
 
-            //mask out this peak so we can find the next biggest
-            for(i=center-ROIwidth; i<=center+ROIwidth; i++){
-                dataCopy[i] = 0
-            }
-
-            max = Math.max.apply(Math, dataCopy);
-            center = dataCopy.indexOf(max);
-            ROIupper = [center - ROIwidth, center + ROIwidth];
-
-            //make sure lower contains the lower energy peak (currently contains the highest intensity peak)
-            if(ROIlower[0] > ROIupper[0]){
-                buffer = JSON.parse(JSON.stringify(ROIlower));
-                ROIlower = JSON.parse(JSON.stringify(ROIupper));
-                ROIupper = JSON.parse(JSON.stringify(buffer));
+                if(centers.length >= highPeakIndex) break;
             }
 
             dataStore.ROI[spectrumName] = {
-                "ROIlower": ROIlower,
-                "ROIupper": ROIupper
+                "ROIlower": [centers[lowPeakIndex-1] - ROIwidth, centers[lowPeakIndex-1] + ROIwidth],
+                "ROIupper": [centers[highPeakIndex-1] - ROIwidth, centers[highPeakIndex-1] + ROIwidth]
             }
-
         },
 
         this.fitCallback = function(center, width, amplitude, intercept, slope){
@@ -324,8 +305,8 @@
             //highBin: number; center of high energy peak in bins
             //this: gainMatchReport object
 
-            var lowEnergy = document.getElementById(this.wrapID + 'peak1').value
-            var highEnergy = document.getElementById(this.wrapID + 'peak2').value
+            var lowEnergy = document.getElementById('peak1').value
+            var highEnergy = document.getElementById('peak2').value
             var slope, intercept;
 
             slope = (lowEnergy - highEnergy) / (lowBin - highBin);

--- a/templates/gainMatchReport/gainMatchSetupBar.html
+++ b/templates/gainMatchReport/gainMatchSetupBar.html
@@ -1,0 +1,18 @@
+<template id='gainMatchSetupBar'>
+    <label for='peak1'>First Peak (position):</label>
+    <input type='number' id='peak1position' class='rowElement' value=1></input>
+    <label for='peak1'>First Peak (keV):</label>
+    <input type='number' id='peak1' class='rowElement' value=1173></input>
+    <label for='peak1'>Second Peak (position):</label>
+    <input type='number' id='peak2position' class='rowElement' value=2></input>
+    <label for='peak1'>Second Peak (keV):</label>
+    <input type='number' id='peak2' class='rowElement' value=1332></input>
+
+    <button type="button" class="btn btn-primary disabled" id='fitAll'>
+        <span id='snapPin' class="glyphicon glyphicon-flash" aria-hidden="true"></span> Automate Gain Match
+    </button>
+
+    <div class="progress">
+      <div id='progress' class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
+    </div>
+</template>

--- a/templates/plotList/plotListLite.html
+++ b/templates/plotList/plotListLite.html
@@ -48,12 +48,8 @@
             listener(
                 this.wrapID, 
                 'fitAllComplete', 
-                function(event){
-                    //open the menu
-                    document.getElementById(this.wrapID + dataStore.plotGroups[0].groupID).click();
-                    //demand the plot
-                    document.getElementById(this.wrapID + dataStore.plotGroups[0].plots[0].plotID).click();
-                }.bind(this)
+                this.snapToTop.bind(this)
+                
             );
         },
 
@@ -102,17 +98,21 @@
             dataStore.currentPlot = plot;
 
             target.plotData();
+
         },
 
-        this.snapToTop = function(){
+        this.snapToTop = function(event){
             //reset display to first plot, first section
             //this: plotListLite object
             
-            //document.getElementById(this.wrapID + dataStore.plotGroups[0].groupID).onclick();
-            //document.getElementById(this.wrapID + dataStore.plotGroups[0].plots[0].plotID).onclick();
-            
-            document.getElementById(this.wrapID + Object.keys(dataStore.rawData)[0].slice(0,5)).onclick();
-            document.getElementById(this.wrapID + Object.keys(dataStore.rawData)[0].slice(0,10)).onclick();
+            if(event){
+                if(document.getElementById(this.wrapID + event.detail.target.slice(0,5)).classList.contains('hidden'))
+                    document.getElementById(this.wrapID + event.detail.target.slice(0,5)).onclick();
+                document.getElementById(this.wrapID + event.detail.target.slice(0,10)).onclick();                
+            } else {
+                document.getElementById(this.wrapID + Object.keys(dataStore.rawData)[0].slice(0,5)).onclick();
+                document.getElementById(this.wrapID + Object.keys(dataStore.rawData)[0].slice(0,10)).onclick();
+            }
 
         }
 


### PR DESCRIPTION
This patch improves peak finding strategy by asking the user to draw a line crossing both peaks of interest in a typical plot. The user then identifies which peaks that cross their line are the ones to pick out (ie "the second and fifth peaks"), and provides corresponding energies.

This has the advantage that it only requires the identification of a search region that always has the same large peaks in it - should be reliable in any situation where we aren't trying to calibrate on a tiny peak sitting in a bunch of noise.
